### PR TITLE
feat: Support http_proxy env vars.

### DIFF
--- a/twint/get.py
+++ b/twint/get.py
@@ -157,7 +157,9 @@ def ForceNewTorIdentity(config):
 
 async def Request(_url, connector=None, params=None, headers=None):
     logme.debug(__name__ + ':Request:Connector')
-    async with aiohttp.ClientSession(connector=connector, headers=headers) as session:
+    async with aiohttp.ClientSession(
+        connector=connector, headers=headers, trust_env=True
+    ) as session:
         return await Response(session, _url, params)
 
 


### PR DESCRIPTION
It supports `HTTP_PROXY`, `HTTPS_PROXY`, `WS_PROXY` or `WSS_PROXY`
environment variables (all are case insensitive). ([ref](https://docs.aiohttp.org/en/stable/client_advanced.html?highlight=proxy#proxy-support))
